### PR TITLE
[Bug] Fix multiple people joining as the same player #

### DIFF
--- a/convex/joinGame.ts
+++ b/convex/joinGame.ts
@@ -1,23 +1,29 @@
 import { mutation } from './_generated/server'
 import { GAME_TABLE } from './common'
+import { Id } from 'convex/values'
 
-const INVALID_PLAYER_ERROR = Error('invalid player number joined');
-
-export default mutation(async ({ db }, playerNumber: number) => {
+export default mutation(async ({ db }): Promise<{
+  // TODO: bring in the named type
+  playerNumber: number,
+  gameID: string,
+}> => {
   let gameState = await db.table(GAME_TABLE).first()
+  let gameID: Id
   const numPlayers = gameState ? gameState.players.length : 0
-  if (playerNumber != numPlayers) {
-    throw INVALID_PLAYER_ERROR
-  }
   if (gameState === null) {
     gameState = {
       players: [{ alive: true }],
       levers: [],
       isStarted: false,
     }
-    db.insert(GAME_TABLE, gameState)
+    gameID = db.insert(GAME_TABLE, gameState)
   } else {
     gameState.players.push({alive: true})
     db.replace(gameState._id, gameState)
+    gameID = gameState._id
+  }
+  return {
+    playerNumber: numPlayers,
+    gameID: gameID.toString()
   }
 })

--- a/pages/LeverGame.tsx
+++ b/pages/LeverGame.tsx
@@ -3,6 +3,17 @@ import { useState } from 'react'
 import { useQuery, useMutation } from '../convex/_generated/react'
 
 const NO_PLAYER = -1
+const NO_GAME_ID = ''
+
+interface LocalGameState {
+  playerNumber: number
+  gameID: string
+}
+
+const dummyLocalState: LocalGameState = {
+  playerNumber: NO_PLAYER,
+  gameID: NO_GAME_ID,
+}
 
 const LeverGame = () => {
   const gameState = useQuery('getGameState') ?? {}
@@ -14,13 +25,23 @@ const LeverGame = () => {
   const numPlayers =
     gameState && gameState.players ? gameState.players.length : 0
 
-  const [playerNumber, setPlayerNumber] = useState(NO_PLAYER)
+  const [localGameState, setLocalGameState] = useState(dummyLocalState)
+  const { playerNumber, gameID } = localGameState
+  // The game in progress isn't the one that's stored locally, which means we have
+  // to invalidate the localstate.
+  if (
+    gameID !== NO_GAME_ID &&
+    gameState._id &&
+    gameState._id.toString() !== gameID
+  ) {
+    setLocalGameState(dummyLocalState)
+  }
 
   const gameInProgress = gameState && gameState.isStarted
 
   const joinGameButtonPressed = async () => {
-    await joinGame(numPlayers)
-    setPlayerNumber(numPlayers)
+    const localGameState = await joinGame()
+    setLocalGameState(localGameState)
   }
 
   const startGameButtonPressed = () => {


### PR DESCRIPTION
The underlying cause of the issue involved w/ our joining logic is that we weren't able to invalidate local component state when the game "restarted." In order to do this, we ended up pinning the local state to a particular gameID. When we notice that this gameID changes, then we invalidate all local state.